### PR TITLE
MDLSITE-8011: Upgrade Bootstrap 5 dropdown menu

### DIFF
--- a/templates/toggleinlinestranslationstate.mustache
+++ b/templates/toggleinlinestranslationstate.mustache
@@ -1,9 +1,9 @@
 <div class="popover-region dropdown translation-icon-wrapper">
-    <a class="nav-link position-relative icon-no-margin" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#" role="button">
+    <a class="nav-link position-relative icon-no-margin" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#" role="button">
         <i class="icon icon-translate-default">
         </i>
     </a>
-    <div class="dropdown-menu dropdown-menu-right menu" aria-labelledby="dropdownMenuButton">
+    <div class="dropdown-menu dropdown-menu-end menu" aria-labelledby="dropdownMenuButton">
         {{#skiplanguage}}
             <p class="alert alert-info small px-3 py-2 my-0 mx-2">{{#str}}cannottranslatelang, filter_translations{{/str}}</p>
         {{/skiplanguage}}


### PR DESCRIPTION
Hi Rajneel,

While testing the filter in Moodle 5.0 beta, we noticed that the dropdown menu behaviour was not functional due to changes introduced in Bootstrap 5.
To fix this, I applied the changes from this branch:

- Updating the `data-toggle="dropdown"` to `data-bs-toggle="dropdown"`.
- Ensuring the dropdown opens correctly, replacing class `dropdown-menu-right` with `dropdown-menu-end`.

Regards